### PR TITLE
Add kubectl command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This will build the NGINX Plus Docker image locally and upload it to the local c
 Next we're installing cert-manager. cert-manager will allow you to integrate the Venafi platforms with Kubernetes to issue TLS certificates and provide identity management for applications across your cluster
 To install cert-manager run:
 ```console
-$ kubectl apply --validate=false -f "https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml"
+$ kubectl apply -f "https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml"
 ```
 This will install cert-manager in its default configuration inside the cluster.
 


### PR DESCRIPTION
Add kubectl command to install cert-manager to the readme to show how easy it is

Signed-off-by: Maartje Eyskens <maartje@eyskens.me>