### PR TITLE
Issue a certificate move workload to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ spec:
 ```
 
 Here we see a certificate resource for `demo.example.com` issued by the `venafi-tpp-issuer` we created before.
-We can nog add it to out cluster using:
+We can w add it to our cluster using:
 ```console
 $ kubectl apply -f certificate.yaml
 ```
@@ -243,7 +243,7 @@ $ kubectl get certificates
 NAME               READY   SECRET     AGE
 demo-certificate   True    demo-tls   10s
 ```
-When creating a `Certificate` resource cert-manager will generate a private key and a Certificate Signing Request. The private key is stored inside the secret we defined in teh configuration: `demo-tls`. This is stored in the Kubernetes secret store.
+When creating a `Certificate` resource, cert-manager will generate a private key and a Certificate Signing Request. The private key is stored inside the Secret resource we defined in the configuration: `demo-tls`. This is stored in the Kubernetes secret store.
 The Certificate Signing Request (CSR) is stored inside a newly generated `CertificateRequest` resource.
 ```console
 $ kubectl get certificaterequests
@@ -291,9 +291,9 @@ Events:
 
 ```
 
-Here we see our generated CSR and Certificate (both base64 encoded), as well as detailed info of the status of the CertificateRequest.
+Here we see our generated CSR and Certificate (both base64 encoded), as well as detailed info of the status of the CertificateRequest. More information about this resource can be found in the [cert-manager documentatiom](https://cert-manager.io/docs/concepts/certificaterequest/)
 
-Once we see here that our certificate is issued by the Venafi TPP instance we can do the same describe on our secret resource that we asked cert-manager to put the certificate into:
+Once we see here that our certificate is issued by the Venafi TPP instance we can do the same describe on the Secret resource that we asked cert-manager to put the certificate into:
 ```console
 $ kubectl describe secret demo-tls
 Name:         demo-tls

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ spec:
 ```
 
 Here we see a certificate resource for `demo.example.com` issued by the `venafi-tpp-issuer` we created before.
-We can w add it to our cluster using:
+We can add it to our cluster using:
 ```console
 $ kubectl apply -f certificate.yaml
 ```
@@ -291,7 +291,7 @@ Events:
 
 ```
 
-Here we see our generated CSR and Certificate (both base64 encoded), as well as detailed info of the status of the CertificateRequest. More information about this resource can be found in the [cert-manager documentatiom](https://cert-manager.io/docs/concepts/certificaterequest/)
+Here we see our generated CSR and Certificate (both base64 encoded), as well as detailed info of the status of the CertificateRequest. More information about this resource can be found in the [cert-manager documentation](https://cert-manager.io/docs/concepts/certificaterequest/)
 
 Once we see here that our certificate is issued by the Venafi TPP instance we can do the same describe on the Secret resource that we asked cert-manager to put the certificate into:
 ```console
@@ -391,7 +391,7 @@ $ curl https://localhost:4430 -k -v
 *  SSL certificate verify result: self signed certificate in certificate chain (19), continuing anyway.
 ```
 
-Notice that the issue in this example is being signed by a training Venafi TPP instance which is not a trusted certificate authority.
+Notice that the issuer in this example is being signed by a training Venafi TPP instance which is not a trusted certificate authority.
 
 ### Securing an Ingress
 
@@ -443,7 +443,7 @@ The NGINX Ingress controller has native support for reading TLS secrets from Kub
 #### Using curl
 You can see it being served using:
 ```console
-$ curl https://<hostname> -k -v
+$ curl -k -v https://<hostname>
 [...]
 * SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
 * ALPN, server accepted to use http/1.1

--- a/certificate.yaml
+++ b/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: demo-certificate
+  namespace: default
+spec:
+  secretName: demo-tls
+  duration: 2160h # 90d
+  dnsNames:
+    - demo.example.com
+  issuerRef:
+    name: venafi-tpp-issuer
+    kind: Issuer

--- a/certificate.yaml
+++ b/certificate.yaml
@@ -11,4 +11,4 @@ spec:
     - demo.example.com
   issuerRef:
     name: venafi-tpp-issuer
-    kind: Issuer
+    kind: Issue


### PR DESCRIPTION
This adds a first step where we issue a demo cert and look into how cert-manager handles it first, then we do the workload then the ingress.
