### PR TITLE
Install latest version of cert-manager

### DIFF
--- a/setup-cert-manager.sh
+++ b/setup-cert-manager.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION=v0.13.1
+VERSION=v0.14.1
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
We no longer use this script in the instructions, but it is useful for testing.

Signed-off-by: Richard Wall <richard.wall@jetstack.io>