### PR TITLE
Restart pod on renewal

### DIFF
--- a/pingpong/main.go
+++ b/pingpong/main.go
@@ -170,14 +170,8 @@ func reloadOnTLSChange(servers []*http.Server) {
 
 		if !bytes.Equal(newCert, originalCert) {
 			originalCert = newCert
-			log.Println("Certificate renewed")
-			for _, server := range servers {
-				// stop and start server with new TLS cert
-				server.Close()
-				go func(s *http.Server) {
-					log.Println(s.ListenAndServeTLS(certFile, keyFile))
-				}(server)
-			}
+			log.Println("Certificate renewed, restarting pod")
+			os.Exit(1)
 		}
 	}
 }

--- a/pingpong/main.go
+++ b/pingpong/main.go
@@ -66,6 +66,9 @@ func main() {
 		log.Fatal("Needs -endpoint, -ca-file, -cert-file and -key-file flags")
 	}
 
+	// watch the certificate file on disk
+	go reloadOnTLSChange()
+
 	http.HandleFunc("/", serveRoot)
 	http.HandleFunc("/ping", servePing)
 
@@ -93,8 +96,6 @@ func main() {
 	go func() {
 		log.Println(externalServer.ListenAndServeTLS(certFile, keyFile)) // run external endpoint where no auth is needed
 	}()
-
-	go reloadOnTLSChange([]*http.Server{internalServer, externalServer})
 
 	// waiting for a signal to exit
 	sigs := make(chan os.Signal, 1)
@@ -155,7 +156,7 @@ func callServer() (*http.Response, error) {
 }
 
 // poor way to reload on cert renewal, works for this demo
-func reloadOnTLSChange(servers []*http.Server) {
+func reloadOnTLSChange() {
 	originalCert, err := ioutil.ReadFile(certFile)
 	if err != nil {
 		log.Fatal(err)
@@ -169,7 +170,6 @@ func reloadOnTLSChange(servers []*http.Server) {
 		}
 
 		if !bytes.Equal(newCert, originalCert) {
-			originalCert = newCert
 			log.Println("Certificate renewed, restarting pod")
 			os.Exit(1)
 		}


### PR DESCRIPTION
The reloading of the HTTP server has some troubles. Since this is a demo app I think it is fine to exit the program on a renewed certificate file and let Kubernetes handle the restarting of it.
This fixes the bug where a certificate renewal breaks the server.